### PR TITLE
Fixed errors around new disk creation

### DIFF
--- a/qm-build-debian-template
+++ b/qm-build-debian-template
@@ -134,6 +134,7 @@ set -ex
 /usr/sbin/qm create "${VMID}" \
 	--name "${VMNAME}" \
 	--cdrom "${VMSTORAGE}:cloudinit" \
+	--net0 virtio,bridge=vmbr0 \
 	--serial0 socket --vga serial0 \
 	--scsihw virtio-scsi-pci \
 	--agent 1 \
@@ -146,10 +147,10 @@ set -ex
 	--output "${OUTPUT}" \
 
 # Import the created disk to local-lvm storage.
-/usr/sbin/qm importdisk "${VMID}" "${OUTPUT}.qcow2" "${VMSTORAGE}"
+/usr/sbin/qm importdisk "${VMID}" "${OUTPUT}.qcow2" "${VMSTORAGE}" --format qcow2
 
 # Attach the new disk to the VM as scsi drive with discard enabled.
-/usr/sbin/qm set "${VMID}" --scsi0 "${VMSTORAGE}:vm-${VMID}-disk-0,discard=on"
+/usr/sbin/qm set "${VMID}" --scsi0 "${VMSTORAGE}:${VMID}/vm-${VMID}-disk-0.qcow2,discard=on"
 
 # Set boot disk.
 /usr/sbin/qm set "${VMID}" --boot c --bootdisk scsi0


### PR DESCRIPTION
Thanks for this script! I was about to try something like this myself, until I found this.

I ran in some issues that I fixed and are "working on my machine".\
This is what initially went wrong over here:

```txt
Finished.
+ /usr/sbin/qm importdisk 901 /tmp/qm-build-debian-template.YLPFFlpQ3R.qcow2 local
Formatting '/var/lib/vz/images/901/vm-901-disk-0.raw', fmt=raw size=2147483648
    (100.00/100%)
+ /usr/sbin/qm set 901 --scsi0 local:vm-901-disk-0,discard=on
unable to parse directory volume name 'vm-901-disk-0'
```

**Fixes**:
- disk was imported as "raw", not "qcow2"
- directory volume name was missing the VMID
- attaching the disk needs path, name and extension "qcow2"
- added a network device